### PR TITLE
-lオプションを追加

### DIFF
--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -2,33 +2,94 @@
 # frozen_string_literal: true
 
 require 'optparse'
+require 'etc'
 
-options = ARGV.getopts('r')
-files_of_directory = options['r'] ? Dir.glob('*').reverse : Dir.glob('*')
+options = ARGV.getopts('l')
+files_of_directory = Dir.glob('*')
 
-def make_divided_list(input, num)
-  num_to_slice = (input.size.to_f / num).ceil
+def make_divided_list(files, num)
+  num_to_slice = (files.size.to_f / num).ceil
 
-  ret = input.each_slice(num_to_slice).to_a
+  ret = files.each_slice(num_to_slice).to_a
   ret.last << nil while ret.last.size < num_to_slice
 
   ret
 end
 
-def make_adjustment_width(files_of_directory, multiple)
-  max_filename_length = files_of_directory.max_by(&:size).size
+def make_adjustment_width(files, multiple)
+  max_filename_length = files.max_by(&:size).size
   (max_filename_length / multiple + 1) * multiple
 end
 
-def show_file(divided_list, adjustment_width)
-  divided_list.transpose.each do |list|
-    list.each do |file|
-      print file.to_s.ljust(adjustment_width)
+def show_files(list, num)
+  list.transpose.each do |files|
+    files.each do |file|
+      print file.to_s.ljust(num)
     end
     print "\n"
   end
 end
 
+file_stat_list = files_of_directory.map { |file| File::Stat.new(file) }
+numbers_of_adjustment_width = {
+  max_digit_of_num_of_link: file_stat_list.map { |stat| stat.nlink.to_s.size }.max,
+  max_user_name_length: file_stat_list.map { |stat| Etc.getpwuid(stat.uid).name.size }.max,
+  max_group_name_length: file_stat_list.map { |stat| Etc.getgrgid(stat.gid).name.size }.max,
+  max_digit_of_file_size: file_stat_list.map { |stat| stat.size.to_s.size }.max
+}
+
+def convert_to_permission(num)
+  {
+    '0' => '---',
+    '1' => '--x',
+    '2' => '-w-',
+    '3' => '-wx',
+    '4' => 'r--',
+    '5' => 'r-x',
+    '6' => 'rw-',
+    '7' => 'rwx'
+  }[num]
+end
+
+def show_total_of_blocks(files)
+  total = 0
+
+  files.each do |file|
+    file = File::Stat.new(file)
+    total += file.blocks
+  end
+  puts "total #{total}"
+end
+
+def show_file_stats(files, numbers)
+  files.each do |file|
+    fs = File::Stat.new(file)
+    file_permission = [
+      fs.ftype == 'file' ? '-' : fs.ftype[0],
+      fs.mode.to_s(8)[-3, 3].chars.map { |num| convert_to_permission(num) }.join
+    ].join
+    time_format = fs.mtime.between?(Time.now - 15_552_000, Time.now) ? '%_m %e %R' : '%_m %e  %Y'
+
+    file_stats = [
+      file_permission,
+      fs.nlink.to_s.rjust(numbers[:max_digit_of_num_of_link] + 1),
+      Etc.getpwuid(fs.uid).name.ljust(numbers[:max_user_name_length] + 1),
+      Etc.getgrgid(fs.gid).name.ljust(numbers[:max_group_name_length] + 1),
+      fs.size.to_s.rjust(numbers[:max_digit_of_file_size]),
+      fs.mtime.strftime(time_format),
+      file
+    ].join(' ')
+
+    puts file_stats
+  end
+end
+
 divided_list = make_divided_list(files_of_directory, 3)
 adjustment_width = make_adjustment_width(files_of_directory, 8)
-show_file(divided_list, adjustment_width)
+
+if options['l'] == true
+  show_total_of_blocks(files_of_directory)
+  show_file_stats(files_of_directory, numbers_of_adjustment_width)
+else
+  show_files(divided_list, adjustment_width)
+end

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -33,14 +33,6 @@ def show_files(files)
   end
 end
 
-file_stat_list = files_of_directory.map { |file| File::Stat.new(file) }
-numbers_of_adjustment_width = {
-  max_digit_of_num_of_link: file_stat_list.map { |stat| stat.nlink.to_s.size }.max,
-  max_user_name_length: file_stat_list.map { |stat| Etc.getpwuid(stat.uid).name.size }.max,
-  max_group_name_length: file_stat_list.map { |stat| Etc.getgrgid(stat.gid).name.size }.max,
-  max_digit_of_file_size: file_stat_list.map { |stat| stat.size.to_s.size }.max
-}
-
 def convert_to_symbol(str)
   {
     '0' => '---',
@@ -63,6 +55,16 @@ end
 
 def make_last_modified_time(file_stat)
   file_stat.mtime.strftime(file_stat.mtime.between?(Time.now - 15_552_000, Time.now) ? '%_m %e %R' : '%_m %e  %Y')
+end
+
+def make_adjustment_width_numbers(files)
+  file_stat_list = files.map { |file| File::Stat.new(file) }
+  {
+    max_digit_of_num_of_link: file_stat_list.map { |stat| stat.nlink.to_s.size }.max,
+    max_owner_name_length: file_stat_list.map { |stat| Etc.getpwuid(stat.uid).name.size }.max,
+    max_group_name_length: file_stat_list.map { |stat| Etc.getgrgid(stat.gid).name.size }.max,
+    max_digit_of_num_of_byte: file_stat_list.map { |stat| stat.size.to_s.size }.max
+  }
 end
 
 def show_total_of_blocks(files)

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -91,8 +91,12 @@ def show_total_of_blocks(files)
   puts "total #{total}"
 end
 
-divided_list = make_divided_list(files_of_directory, 3)
-adjustment_width = make_adjustment_width(files_of_directory, 8)
+def show_file_stats(files)
+  display_format_list = make_display_format_list(files)
+  file_stats = display_format_list.map { |stat| stat.join(' ') }.join("\n")
+  show_total_of_blocks(files)
+  puts file_stats
+end
 
 if options['l'] == true
   show_total_of_blocks(files_of_directory)

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -77,26 +77,21 @@ def show_total_of_blocks(files)
   puts "total #{total}"
 end
 
-def show_file_stats(files, numbers)
-  files.each do |file|
+def make_display_format_list(files)
+  numbers = make_adjustment_width_numbers(files)
+
+  files.map do |file|
     fs = File::Stat.new(file)
-    file_permission = [
-      fs.ftype == 'file' ? '-' : fs.ftype[0],
-      fs.mode.to_s(8)[-3, 3].chars.map { |num| convert_to_permission(num) }.join
-    ].join
-    time_format = fs.mtime.between?(Time.now - 15_552_000, Time.now) ? '%_m %e %R' : '%_m %e  %Y'
 
-    file_stats = [
-      file_permission,
+    [
+      make_file_mode(fs),
       fs.nlink.to_s.rjust(numbers[:max_digit_of_num_of_link] + 1),
-      Etc.getpwuid(fs.uid).name.ljust(numbers[:max_user_name_length] + 1),
+      Etc.getpwuid(fs.uid).name.ljust(numbers[:max_owner_name_length] + 1),
       Etc.getgrgid(fs.gid).name.ljust(numbers[:max_group_name_length] + 1),
-      fs.size.to_s.rjust(numbers[:max_digit_of_file_size]),
-      fs.mtime.strftime(time_format),
+      fs.size.to_s.rjust(numbers[:max_digit_of_num_of_byte]),
+      make_last_modified_time(fs),
       file
-    ].join(' ')
-
-    puts file_stats
+    ]
   end
 end
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -61,6 +61,10 @@ def make_file_mode(file_stat)
   ].join
 end
 
+def make_last_modified_time(file_stat)
+  file_stat.mtime.strftime(file_stat.mtime.between?(Time.now - 15_552_000, Time.now) ? '%_m %e %R' : '%_m %e  %Y')
+end
+
 def show_total_of_blocks(files)
   total = 0
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -48,7 +48,7 @@ end
 
 def make_file_mode(file_stat)
   [
-    file_stat.ftype == 'file' ? '-' : fs.ftype[0],
+    file_stat.ftype == 'file' ? '-' : file_stat.ftype[0],
     file_stat.mode.to_s(8)[-3, 3].chars.map { |str| convert_to_symbol(str) }.join
   ].join
 end
@@ -67,13 +67,12 @@ def make_adjustment_width_numbers(files)
   }
 end
 
-
 def make_display_format_list(files)
   numbers = make_adjustment_width_numbers(files)
-  
+
   files.map do |file|
     fs = File::Stat.new(file)
-    
+
     [
       make_file_mode(fs),
       fs.nlink.to_s.rjust(numbers[:max_digit_of_num_of_link] + 1),
@@ -98,9 +97,4 @@ def show_file_stats(files)
   puts file_stats
 end
 
-if options['l'] == true
-  show_total_of_blocks(files_of_directory)
-  show_file_stats(files_of_directory, numbers_of_adjustment_width)
-else
-  show_files(divided_list, adjustment_width)
-end
+options['l'] == true ? show_file_stats(files_of_directory) : show_files(files_of_directory)

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -54,7 +54,7 @@ def make_file_mode(file_stat)
 end
 
 def make_last_modified_time(file_stat)
-  file_stat.mtime.strftime(file_stat.mtime.between?(Time.now - 15_552_000, Time.now) ? '%_m %e %R' : '%_m %e  %Y')
+  file_stat.mtime.strftime(file_stat.mtime.between?(Time.now - (60 * 60 * 24 * 180), Time.now) ? '%_m %e %R' : '%_m %e  %Y')
 end
 
 def make_adjustment_width_numbers(files)

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -67,22 +67,13 @@ def make_adjustment_width_numbers(files)
   }
 end
 
-def show_total_of_blocks(files)
-  total = 0
-
-  files.each do |file|
-    file = File::Stat.new(file)
-    total += file.blocks
-  end
-  puts "total #{total}"
-end
 
 def make_display_format_list(files)
   numbers = make_adjustment_width_numbers(files)
-
+  
   files.map do |file|
     fs = File::Stat.new(file)
-
+    
     [
       make_file_mode(fs),
       fs.nlink.to_s.rjust(numbers[:max_digit_of_num_of_link] + 1),
@@ -93,6 +84,11 @@ def make_display_format_list(files)
       file
     ]
   end
+end
+
+def show_total_of_blocks(files)
+  total = files.map { |file| File::Stat.new(file).blocks }.sum
+  puts "total #{total}"
 end
 
 divided_list = make_divided_list(files_of_directory, 3)

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -54,6 +54,13 @@ def convert_to_symbol(str)
   }[str]
 end
 
+def make_file_mode(file_stat)
+  [
+    file_stat.ftype == 'file' ? '-' : fs.ftype[0],
+    file_stat.mode.to_s(8)[-3, 3].chars.map { |str| convert_to_symbol(str) }.join
+  ].join
+end
+
 def show_total_of_blocks(files)
   total = 0
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -21,10 +21,13 @@ def make_adjustment_width(files, multiple)
   (max_filename_length / multiple + 1) * multiple
 end
 
-def show_files(list, num)
-  list.transpose.each do |files|
-    files.each do |file|
-      print file.to_s.ljust(num)
+def show_files(files)
+  divided_list = make_divided_list(files, 3)
+  adjustment_width = make_adjustment_width(files, 8)
+
+  divided_list.transpose.each do |files_divided|
+    files_divided.each do |file|
+      print file.to_s.ljust(adjustment_width)
     end
     print "\n"
   end

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -41,7 +41,7 @@ numbers_of_adjustment_width = {
   max_digit_of_file_size: file_stat_list.map { |stat| stat.size.to_s.size }.max
 }
 
-def convert_to_permission(num)
+def convert_to_symbol(str)
   {
     '0' => '---',
     '1' => '--x',
@@ -51,7 +51,7 @@ def convert_to_permission(num)
     '5' => 'r-x',
     '6' => 'rw-',
     '7' => 'rwx'
-  }[num]
+  }[str]
 end
 
 def show_total_of_blocks(files)


### PR DESCRIPTION
お疲れ様です。
lsコマンド`-l`オプションを実装しました。
メソッド`convert_to_permission`でパーミションの数値（文字列）を対応する文字列に変換します。
メソッド`show_total_of_blocks`でディレクトリ内のブロック数の合計を計算し表示します。
メソッド`show_file_stats`でファイルのステータスを表示します。
`show_file_stats`内の変数`time_format`にはファイルの最終更新日が半年以内か、そうでないかでそれぞれの場合の表示フォーマットが代入されるようにしてます。（Timeクラスを調べたところ、何ヶ月前を指定するメソッドがなかったため、`-`メソッドを使って秒単位で計算してます。`15_552_000 = 60 * 60 * 24 * 30 * 6`。ただし正確ではないと思うため、何か他に良い方法がありましたら、ご教示お願いいたします。）
変数`numbers_of_adjustment_width`は`show_file_stats`に引数で渡し、それぞれリンク数、ユーザー名、グループ名、バイト数の表示幅を調整します。

ご確認よろしくお願いいたします！