### PR TITLE
オプション-a,-l,-rを共存

### DIFF
--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -4,8 +4,16 @@
 require 'optparse'
 require 'etc'
 
-options = ARGV.getopts('l')
-files_of_directory = Dir.glob('*')
+options = ARGV.getopts('alr')
+files_of_directory = if options['a'] == true && options['r'] == true
+                       Dir.glob('*', File::FNM_DOTMATCH).reverse
+                     elsif options['a'] == true
+                       Dir.glob('*', File::FNM_DOTMATCH)
+                     elsif options['r'] == true
+                       Dir.glob('*').reverse
+                     else
+                       Dir.glob('*')
+                     end
 
 def make_divided_list(files, num)
   num_to_slice = (files.size.to_f / num).ceil

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -5,15 +5,9 @@ require 'optparse'
 require 'etc'
 
 options = ARGV.getopts('alr')
-files_of_directory = if options['a'] == true && options['r'] == true
-                       Dir.glob('*', File::FNM_DOTMATCH).reverse
-                     elsif options['a'] == true
-                       Dir.glob('*', File::FNM_DOTMATCH)
-                     elsif options['r'] == true
-                       Dir.glob('*').reverse
-                     else
-                       Dir.glob('*')
-                     end
+files_of_directory = options['a'] == true ? Dir.glob('*', File::FNM_DOTMATCH) : Dir.glob('*')
+
+files_of_directory.reverse! if options['r'] == true
 
 def make_divided_list(files, num)
   num_to_slice = (files.size.to_f / num).ceil


### PR DESCRIPTION
`-l`オプションのコードに、変数`files_of_directory`へ代入する値の条件分岐を追加して、`-a`,`-l`,`-r`オプションが共存したコードを実装しました。
ご確認よろしくお願いいたします！